### PR TITLE
Unit tags

### DIFF
--- a/demo/tessv5_demo.ipynb
+++ b/demo/tessv5_demo.ipynb
@@ -12,9 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
@@ -27,7 +25,7 @@
     "from tesserae.matchers import AggregationMatcher\n",
     "\n",
     "# Set up the connection and clean up the database\n",
-    "connection = TessMongoConnection('127.0.0.1', 27017, None, None, 'tesstest')\n",
+    "connection = TessMongoConnection('45.55.219.221', 27017, None, None, 'tesstest')\n",
     "\n",
     "# Clean up the previous demo\n",
     "connection.connection['feature_sets'].delete_many({})\n",
@@ -53,9 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with open('text_metadata.json', 'r') as f:\n",
@@ -77,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "texts = []\n",
@@ -100,9 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "texts = connection.find('texts', _id=result.inserted_ids)\n",
@@ -124,9 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tessfile = TessFile(texts[0].path, metadata=texts[0])\n",
@@ -146,9 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lines = tessfile.readlines()\n",
@@ -166,9 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tokens = tessfile.read_tokens()\n",
@@ -182,32 +168,30 @@
    "source": [
     "## Tokenizing a Text\n",
     "\n",
-    "Texts can be tokenized with `tesserae.tokenizers.get_token_info`. This function takes a token and the language to use for lemmatization, etc."
+    "Texts can be tokenized with `tesserae.tokenizers` objects. These objects are designed to normalize and compute features for tokens of a specific language."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "tokenizer = GreekTokenizer(connection) if tessfile.metadata.language == 'greek' else LatinTokenizer(connection)\n",
     "\n",
-    "tokens, frequencies, feature_sets = tokenizer.tokenize(tessfile.read(), text=tessfile.metadata)\n",
+    "tokens, tags, frequencies, feature_sets = tokenizer.tokenize(tessfile.read(), text=tessfile.metadata)\n",
     "\n",
     "tokens = tokenizer.tokens\n",
     "print(len(tokens), len(frequencies), len(feature_sets))\n",
     "\n",
-    "print('{}{}{}{}'.format('Raw'.ljust(15), 'Normalized'.ljust(15), 'Lemmata'.ljust(15), 'Frequency'))\n",
-    "print('{}{}{}{}'.format('---'.ljust(15), '----------'.ljust(15), '-------'.ljust(15), '---------'))\n",
+    "print('{}{}{}{}'.format('Raw'.ljust(15), 'Normalized'.ljust(15), 'Lemmata'.ljust(20), 'Frequency'))\n",
+    "print('{}{}{}{}'.format('---'.ljust(15), '----------'.ljust(15), '-------'.ljust(20), '---------'))\n",
     "for i in range(20):\n",
-    "    if tokenizer.tokens[i].feature_set is not None:\n",
+    "    if tokenizer.tokens[i].feature_set is not None and not isinstance(tokenizer.tokens[i].feature_set, str):\n",
     "        print('{}{}{}{}'.format(tokenizer.tokens[i].display.ljust(15),\n",
-    "                              str(tokenizer.tokens[i].feature_set.form).ljust(15),\n",
-    "                              str(tokenizer.tokens[i].feature_set.lemmata).ljust(15),\n",
-    "                              tokenizer.tokens[i].frequency.frequency))\n"
+    "                              str(tokenizer.tokens[i].feature_set.form).ljust(20),\n",
+    "                              str(tokenizer.tokens[i].feature_set.lemmata).ljust(20),\n",
+    "                              tokenizer.tokens[i].frequency.frequency))"
    ]
   },
   {
@@ -220,19 +204,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "result = connection.insert(feature_sets)\n",
     "print('Inserted {} feature set entities out of {}'.format(len(result.inserted_ids), len(feature_sets)))\n",
     "\n",
     "result = connection.insert(frequencies)\n",
-    "print('Inserted {} frequency entities out of {}'.format(len(result.inserted_ids), len(frequencies)))\n",
-    "\n",
-    "# result = connection.insert(tokens)\n",
-    "# print('Inserted {} tokens out of {}.'.format(len(result.inserted_ids), len(tokens)))"
+    "print('Inserted {} frequency entities out of {}'.format(len(result.inserted_ids), len(frequencies)))"
    ]
   },
   {
@@ -247,35 +226,32 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Unitizing lines of a poem\n",
     "unitizer = Unitizer()\n",
-    "lines, phrases = unitizer.unitize(tokens, tessfile.metadata)\n",
+    "lines, phrases = unitizer.unitize(tokens, tags, tessfile.metadata)\n",
     "\n",
     "print('Lines\\n-----')\n",
     "for line in lines[:20]:\n",
-    "        print(''.join([t.display for t in line.tokens]))\n",
+    "        print(''.join([str(line.tags), ': '] + [t.display for t in line.tokens]))\n",
     "        \n",
     "print('\\n\\nPhrases\\n-------')\n",
     "for phrase in phrases[:20]:\n",
-    "        print(''.join([t.display for t in phrase.tokens]))"
+    "        print(''.join([str(phrase.tags), ': '] + [t.display for t in phrase.tokens]))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Unitizing phrases of a poem or prose\n",
     "result = connection.insert(lines + phrases)\n",
     "print('Inserted {} units out of {}.'.format(len(result.inserted_ids), len(lines + phrases)))\n",
+    "\n",
     "\n",
     "result = connection.insert(tokens)\n",
     "print('Inserted {} tokens out of {}.'.format(len(result.inserted_ids), len(tokens)))"
@@ -284,9 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for text in texts[1:]:\n",
@@ -294,14 +268,14 @@
     "    tokenizer = GreekTokenizer(connection) if tessfile.metadata.language == 'greek' else LatinTokenizer(connection)\n",
     "\n",
     "    \n",
-    "    tokens, frequencies, feature_sets = tokenizer.tokenize(tessfile.read(), text=tessfile.metadata)\n",
+    "    tokens, tags, frequencies, feature_sets = tokenizer.tokenize(tessfile.read(), text=tessfile.metadata)\n",
     "        \n",
     "    tokens = tokenizer.tokens\n",
     "    result = connection.insert(feature_sets)\n",
     "    result = connection.insert(frequencies)\n",
     "    \n",
     "    unitizer = Unitizer()\n",
-    "    lines, phrases = unitizer.unitize(tokens, tessfile.metadata)\n",
+    "    lines, phrases = unitizer.unitize(tokens, tags, tessfile.metadata)\n",
     "    result = connection.insert(lines + phrases)\n",
     "    \n",
     "    result = connection.insert(tokens)"
@@ -319,17 +293,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import time\n",
     "matcher = AggregationMatcher(connection)\n",
-    "match_texts = [t for t in texts if t.language == 'latin']\n",
+    "match_texts = [t for t in texts if t.language == 'greek']\n",
     "\n",
     "start = time.time()\n",
-    "matches, match_set = matcher.match(match_texts, 'phrase', 'form', distance_metric='span', max_distance=999)\n",
+    "matches, match_set = matcher.match(match_texts, 'phrase', 'form', distance_metric='span', stopwords=20, max_distance=10)\n",
     "print(\"Completed matching in {0:.2f}s\".format(time.time() - start))\n",
     "\n",
     "matches.sort(key=lambda x: x.score, reverse=True)\n",
@@ -343,9 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "matches = connection.aggregate('matches', [\n",
@@ -387,21 +357,19 @@
     "])\n",
     "\n",
     "print('\\n')\n",
-    "print('{}{}{}'.format('Score'.ljust(15), 'Match Tokens'.ljust(15), 'Source Text'.ljust(15), 'Target Text'))\n",
-    "print('{}{}{}'.format('-----'.ljust(15), '------------'.ljust(15), '-----------'.ljust(15), '-----------'))\n",
+    "print('{}{}'.format('Score'.ljust(15), 'Match Tokens'.ljust(15)))\n",
+    "print('{}{}'.format('-----'.ljust(15), '------------'.ljust(15)))\n",
     "for m in matches:\n",
     "    print('{}{}'.format(('%.3f'%(m.score)).ljust(15), ', '.join(list(set([t['form'] for t in m.tokens])))))\n",
-    "    print('Source Text: {}'.format(''.join([t['display'] for t in m.units[0]['tokens']])))\n",
-    "    print('Target Text: {}'.format(''.join([t['display'] for t in m.units[1]['tokens']])))\n",
+    "    print('{} {} {}: {}'.format(match_texts[0].author, match_texts[0].title, m.units[0]['tags'], ''.join([t['display'] for t in m.units[0]['tokens']])))\n",
+    "    print('{} {} {}: {}'.format(match_texts[1].author, match_texts[1].title, m.units[1]['tags'], ''.join([t['display'] for t in m.units[1]['tokens']])))\n",
     "    print('\\n')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -409,9 +377,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda env:tessv5]",
+   "display_name": "tess-env",
    "language": "python",
-   "name": "conda-env-tessv5-py"
+   "name": "tess-env"
   },
   "language_info": {
    "codemirror_mode": {
@@ -423,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/tesserae/db/entities/match_set.py
+++ b/tesserae/db/entities/match_set.py
@@ -72,7 +72,7 @@ class MatchSet(Entity):
         uniques = {
             'texts': [t.id if isinstance(t, Entity) else t
                       for t in self.texts],
-            'unit_type': self.unit_type,
+            'unit_types': self.unit_types,
             'feature': self.feature,
             'parameters': self.parameters
         }

--- a/tesserae/db/entities/token.py
+++ b/tesserae/db/entities/token.py
@@ -112,5 +112,8 @@ class Token(Entity):
         return obj
 
     def unique_values(self):
-        uniques = {'text': self.text.id, 'index': self.index}
+        uniques = {
+            'text': self.text.id if isinstance(self.text, Entity) else self.text,
+            'index': self.index
+        }
         return uniques

--- a/tesserae/db/entities/unit.py
+++ b/tesserae/db/entities/unit.py
@@ -79,7 +79,7 @@ class Unit(Entity):
 
     def unique_values(self):
         uniques = {
-            'text': self.text.id,
+            'text': self.text.id if isinstance(self.text, Entity) else self.text,
             'index': self.index,
             'unit_type': self.unit_type}
         return uniques

--- a/tesserae/db/entities/unit.py
+++ b/tesserae/db/entities/unit.py
@@ -42,6 +42,9 @@ class Unit(Entity):
     index : int
         The order of this unit in the text. This is relative to Units of a
         particular type.
+    tags : list of str
+        The in-text locale tag(s) associated with the unit. Correponds to,
+        e.g., lines of a poem or sentences/paragraphs of prose.
     unit_type : str
         How the chunk of text in this Unit was defined, e.g., "line",
         "phrase", etc.
@@ -52,11 +55,12 @@ class Unit(Entity):
 
     collection = 'units'
 
-    def __init__(self, id=None, text=None, index=None, unit_type=None,
+    def __init__(self, id=None, text=None, index=None, tags=None, unit_type=None,
                  tokens=None):
         super(Unit, self).__init__(id=id)
         self.text: typing.Optional[ObjectId] = text
         self.index: typing.Optional[int] = index
+        self.tags: typing.List[str] = tags if tags is not None else []
         self.unit_type: typing.Optional[str] = unit_type
         self.tokens: typing.List[typing.Union[ObjectId, Entity]] = \
             tokens if tokens is not None else []

--- a/tesserae/db/mongodb.py
+++ b/tesserae/db/mongodb.py
@@ -185,7 +185,11 @@ class TessMongoConnection():
                 else:
                     filter_vals[k] = [v]
 
-        exists = self.find(entity[0].collection, **filter_vals)
+        try:
+            exists = self.find(entity[0].collection, **filter_vals)
+        except IndexError:
+            pass
+            
 
         if len(exists) != 0:
             exists = [e.unique_values() for e in exists]

--- a/tesserae/db/mongodb.py
+++ b/tesserae/db/mongodb.py
@@ -199,11 +199,11 @@ class TessMongoConnection():
             collection = self.connection[entity[0].__class__.collection]
             result = collection.insert_many(
                 [e.json_encode(exclude=['_id']) for e in entity])
+            for i, e in enumerate(entity):
+                e.id = result.inserted_ids[i]
         except IndexError:
-            raise ValueError("No entities provided.")
+            result = []
 
-        for i, e in enumerate(entity):
-            e.id = result.inserted_ids[i]
         return result
 
     def update(self, entity):

--- a/tesserae/matchers/aggregator.py
+++ b/tesserae/matchers/aggregator.py
@@ -127,28 +127,34 @@ class AggregationMatcher(object):
         stoplist = self.connection.aggregate('frequencies', pipeline, encode=False)
         return [s['_id'] for s in stoplist]
 
-    def match(self, texts, unit_types, feature, stopwords_list=[],
+    def match(self, texts, unit_type, feature, stopwords=10,
+              stopword_basis='corpus', score_basis='word',
               frequency_basis='texts', max_distance=10,
               distance_metric='frequency'):
         """Find matches between one or more texts.
-
         Texts will contain lines or phrases with matching tokens, with varying
         degrees of strength to the match. If one text is provided, each unit in
         the text will be matched with every subsequent unit.
-
         Parameters
         ----------
         texts : list of tesserae.db.Text
             The texts to match. Texts are matched in
-        unit_types : list of strings
-            The type of unit to match on per text; only 'list' and 'phrase' are
-            allowed; the position of an item in texts corresponds to the unit
-            type specified in the corresponding position in this list.
+        unit_type : {'line','phrase'}
+            The type of unit to match on.
         feature : {'form','lemmata','semantic','lemmata + semantic','sound'}
             The token feature to match on.
-        stopwords_list : list of str
-            A list of words to use as stopwords; these must be in normalized
-            form.
+        stopwords : int or list of str
+            The number of stopwords to use, to be retrieved from the database,
+            or else a list of words to use as stopwords.
+        stopword_basis : {'corpus','texts'} or slice or tesserae.db.Text
+            Which frequencies to use when calculating the stoplist.
+            - 'corpus': use the combined frequencies of the entire corpus
+            - 'texts': use the combined frequencies of all texts in the match
+            - slice: use the texts returned from `texts` by the slice
+            - Text: use a single text
+        score_basis : {'word','stem'}
+            Whether to score based on the words (normalized text) or stems
+            (lemmata).
         frequency_basis : {'texts','corpus'}
             Take frequencies from the texts being matched or from the entire
             corpus.
@@ -159,7 +165,11 @@ class AggregationMatcher(object):
             - 'frequency': the distance between the two least frequent words
             - 'span': the greatest distance between any two matching words
         """
-        stoplist = self.get_stoplist(stopwords_list)
+        stoplist = self.create_stoplist(
+            stopwords,
+            'form' if feature == 'form' else 'lemmata',
+            texts[0].language,
+            basis=stopword_basis)
 
         print(stoplist)
         import time
@@ -169,11 +179,12 @@ class AggregationMatcher(object):
 
         match_set = MatchSet(
             texts=texts,
-            unit_types=unit_types,
+            unit_types=unit_type,
             feature=feature,
             parameters={
-                # easier to cache and interpret
-                'stopwords': sorted(stopwords_list),
+                'stopwords': stoplist,
+                'stopword_basis': stopword_basis,
+                'score_basis': score_basis,
                 'frequency_basis': frequency_basis,
                 'max_distance': max_distance,
                 'distance_metric': distance_metric
@@ -211,8 +222,7 @@ class AggregationMatcher(object):
             {'$project': {
                 'text': True,
                 'index': True,
-                # NB this is wrong, but Jeff will be replacing this code
-                'unit': '$' + unit_types[0],
+                'unit': '$' + unit_type,
                 'feature': {'$arrayElemAt': ['$feature_set.' + feature, 0]},
                 'frequency': {'$arrayElemAt': ['$frequency.frequency', 0]}
             }}
@@ -248,12 +258,18 @@ class AggregationMatcher(object):
         target = agg_matches[str(texts[1].id)]
 
         p = mp.Pool()
-        results = p.map(score_wrapper, [(unit, target, distance_metric, match_set) for unit in source])
+        results = p.map(score_wrapper, [(unit, target, distance_metric, max_distance, match_set) for unit in source])
         p.close()
         p.join()
 
         for r in results:
             matches.extend(r)
+        min_score = np.min([match.score for match in matches])
+        max_score = np.max([match.score for match in matches]) - min_score
+        for match in matches:
+            match.score = np.abs(np.ceil(10.0 * (match.score - min_score) / max_score))
+            # if match.score > 10:
+            #     match.score = 10.000
 
         return sorted(matches, key=lambda x: x.score, reverse=True), match_set
 
@@ -262,7 +278,7 @@ def score_wrapper(args):
     return score(*args)
 
 
-def score(source_unit, target_units, distance_metric, match_set):
+def score(source_unit, target_units, distance_metric, max_distance, match_set):
     matches = []
     for t in target_units:
         intersect = set(source_unit['features']) & set(t['features'])
@@ -277,22 +293,25 @@ def score(source_unit, target_units, distance_metric, match_set):
             target_frequencies = np.array(t['frequencies'], dtype=np.float32)[target_matches]
 
             if distance_metric == 'frequency':
-                source_dist = np.sum(source_indices[np.argsort(source_frequencies)[:1]])
-                target_dist = np.sum(target_indices[np.argsort(target_frequencies)[:1]])
+                source_dist = source_indices[np.argsort(source_frequencies)[:1]]
+                source_dist = np.abs(source_dist[1] - source_dist[0]) + 1
+                target_dist = target_indices[np.argsort(target_frequencies)[:1]]
+                target_dist = np.abs(target_dist[1] - target_dist[0]) + 1
             else:
-                source_dist = np.abs(np.max(source_matches) - np.min(source_matches))
-                target_dist = np.abs(np.max(target_matches) - np.min(target_matches))
+                source_dist = np.abs(np.max(source_matches) - np.min(source_matches)) + 1
+                target_dist = np.abs(np.max(target_matches) - np.min(target_matches)) + 1
 
-            score = np.log(
-                (np.sum(np.power(source_frequencies, -1)) +
-                 np.sum(np.power(target_frequencies, -1))) /
-                (source_dist + target_dist))
-            matches.append(
-                Match(
-                    units=[source_unit['_id'], t['_id']],
-                    tokens=[source_unit['tokens'][i] for i in source_matches] +
-                           [t['tokens'][i] for i in target_matches],
-                    score=score,
-                    match_set=match_set
-                ))
+            if source_dist < max_distance and target_dist <= max_distance:
+                score = np.log(
+                    (np.sum(np.power(source_frequencies, -1)) +
+                     np.sum(np.power(target_frequencies, -1))) /
+                    (source_dist + target_dist))
+                matches.append(
+                    Match(
+                        units=[source_unit['_id'], t['_id']],
+                        tokens=[source_unit['tokens'][i] for i in source_matches] +
+                               [t['tokens'][i] for i in target_matches],
+                        score=score,
+                        match_set=match_set
+                    ))
     return matches

--- a/tesserae/matchers/aggregator.py
+++ b/tesserae/matchers/aggregator.py
@@ -173,7 +173,7 @@ class AggregationMatcher(object):
                 texts[0].language,
                 basis=stopword_basis)
         else:
-            stoplist = get_stoplist(stoplist)
+            stoplist = get_stoplist(stopwords)
 
         print(stoplist)
         import time

--- a/tesserae/matchers/aggregator.py
+++ b/tesserae/matchers/aggregator.py
@@ -165,11 +165,15 @@ class AggregationMatcher(object):
             - 'frequency': the distance between the two least frequent words
             - 'span': the greatest distance between any two matching words
         """
-        stoplist = self.create_stoplist(
-            stopwords,
-            'form' if feature == 'form' else 'lemmata',
-            texts[0].language,
-            basis=stopword_basis)
+
+        if isinstance(stopwords, int):
+            stoplist = self.create_stoplist(
+                stopwords,
+                'form' if feature == 'form' else 'lemmata',
+                texts[0].language,
+                basis=stopword_basis)
+        else:
+            stoplist = get_stoplist(stoplist)
 
         print(stoplist)
         import time

--- a/tesserae/tokenizers/base.py
+++ b/tesserae/tokenizers/base.py
@@ -104,7 +104,7 @@ class BaseTokenizer(object):
         normalized = re.split(self.split_pattern, normalized, flags=re.UNICODE)
         normalized = [n for n in normalized if n]
 
-        raw = re.sub(r'<.+>\s', '', raw, flags=re.UNICODE)
+        raw = re.sub(r'[<].+[>]\s', '', raw, flags=re.UNICODE)
         raw = re.sub(r'[\n]', r' / ', raw, flags=re.UNICODE)
         display = [t for t in re.split('(<.+>)|( / )|([^' + self.word_characters + '])', raw, flags=re.UNICODE) if t]
         featurized = self.featurize(normalized)
@@ -142,13 +142,9 @@ class BaseTokenizer(object):
 
             try:
                 if re.search(r'<', normalized[norm_i], flags=re.UNICODE):
-                    tag = re.search('([\d]+[.]*[\d]*[a-zA-Z]*)', normalized[norm_i])
+                    tag = re.search('([\d]+[.]*[\d]*[a-z]*)', normalized[norm_i], flags=re.UNICODE)
                     tag = tag.group(1)
                     tags.append(tag)
-
-                    #t = Token(text=text, index=-1, display=normalized[norm_i],
-                    #      feature_set=tag, frequency=frequency)
-                    #tokens.append(t)
                     norm_i += 1
             except (IndexError, AttributeError):
                 pass

--- a/tesserae/tokenizers/base.py
+++ b/tesserae/tokenizers/base.py
@@ -103,7 +103,7 @@ class BaseTokenizer(object):
         normalized = self.normalize(raw)
         normalized = re.split(self.split_pattern, normalized, flags=re.UNICODE)
         normalized = [n for n in normalized if n]
-        print(normalized[0])
+
         raw = re.sub(r'<.+>\s', '', raw, flags=re.UNICODE)
         raw = re.sub(r'[\n]', r' / ', raw, flags=re.UNICODE)
         display = [t for t in re.split('(<.+>)|( / )|([^' + self.word_characters + '])', raw, flags=re.UNICODE) if t]
@@ -130,6 +130,8 @@ class BaseTokenizer(object):
         except AttributeError:
             language = None
 
+        tags = []
+
         # Prep the token objects
         base = len(self.tokens)
         norm_i = 0
@@ -140,14 +142,15 @@ class BaseTokenizer(object):
 
             try:
                 if re.search(r'<', normalized[norm_i], flags=re.UNICODE):
-                    tag = re.search(r'([\d]+[.][\d]+)', normalized[norm_i])
+                    tag = re.search('([\d]+[.]*[\d]*[a-zA-Z]*)', normalized[norm_i])
                     tag = tag.group(1)
+                    tags.append(tag)
 
-                    t = Token(text=text, index=-1, display=normalized[norm_i],
-                          feature_set=tag, frequency=frequency)
-                    tokens.append(t)
+                    #t = Token(text=text, index=-1, display=normalized[norm_i],
+                    #      feature_set=tag, frequency=frequency)
+                    #tokens.append(t)
                     norm_i += 1
-            except IndexError:
+            except (IndexError, AttributeError):
                 pass
 
             if re.search('[' + self.word_characters + ']', d, flags=re.UNICODE):
@@ -184,4 +187,4 @@ class BaseTokenizer(object):
             self.feature_sets.update(feature_sets)
             frequencies = self.frequencies
 
-        return tokens, list(frequency_list.values()), new_feature_sets
+        return tokens, tags, list(frequency_list.values()), new_feature_sets

--- a/tesserae/tokenizers/greek.py
+++ b/tesserae/tokenizers/greek.py
@@ -23,7 +23,7 @@ class GreekTokenizer(BaseTokenizer):
         self.diacrit_sub2 = \
             '([\s])([' + self.diacriticals + ']+)([' + self.vowels + ']{1})'
 
-        self.split_pattern = '[<].+[>][\s]| / |[^\w' + self.diacriticals + self.sigma_alt + '\']'
+        self.split_pattern = '([<].+[>])| / |[^\w' + self.diacriticals + self.sigma_alt + '\']'
 
         self.lemmatizer = Lemmata('lemmata', 'greek')
 

--- a/tesserae/tokenizers/greek.py
+++ b/tesserae/tokenizers/greek.py
@@ -59,8 +59,8 @@ class GreekTokenizer(BaseTokenizer):
 
         normalized = re.sub(r'\'', '', normalized, flags=re.UNICODE)
 
-        normalized = re.sub(r'[\'0-9]+', '', normalized,
-                            flags=re.UNICODE)
+        # normalized = re.sub('(?<![<])([0-9]+)(?![>])', '', normalized,
+        #                     flags=re.UNICODE)
 
         return normalized
 

--- a/tesserae/tokenizers/latin.py
+++ b/tesserae/tokenizers/latin.py
@@ -18,7 +18,7 @@ class LatinTokenizer(BaseTokenizer):
         self.lemmatizer = Lemmata('lemmata', 'latin')
 
         self.split_pattern = \
-            '[<].+[>][\s]| / | \. \. \.|\.\~\.\~\.|[^\w' + self.diacriticals + ']'
+            '([<].+[>])| / | \. \. \.|\.\~\.\~\.|[^\w' + self.diacriticals + ']'
 
     # def tokenize(self, raw, record=True, text=None):
     #     normalized = unicodedata.normalize('NFKD', raw).lower()

--- a/tesserae/unitizer.py
+++ b/tesserae/unitizer.py
@@ -110,32 +110,37 @@ class Unitizer(object):
             word = re.search(r'[\w]', t.display, flags=re.UNICODE)
 
             # Get the current line and phrase
-            self.lines[-1].tokens.append(t)
-            t.line = self.lines[-1]
+            if '<' not in t.display:
+                self.lines[-1].tokens.append(t)
+                t.line = self.lines[-1]
 
-            # Handle seeing multiple phrase delimiters in a row
-            if len(self.phrases) > 1 and not word and len(self.phrases[-1].tokens) == 0:
-                self.phrases[-2].tokens.append(t)
-                t.phrase = self.phrases[-2]
-            else:
-                self.phrases[-1].tokens.append(t)
-                t.phrase = self.phrases[-1]
+                # Handle seeing multiple phrase delimiters in a row
+                if len(self.phrases) > 1 and not word and len(self.phrases[-1].tokens) == 0:
+                    self.phrases[-2].tokens.append(t)
+                    t.phrase = self.phrases[-2]
+                else:
+                    self.phrases[-1].tokens.append(t)
+                    t.phrase = self.phrases[-1]
 
-            # If this token contains a newline or the Tesserae line delimiter,
-            # create a new line unit and append it for the next iteration.
-            if re.search(r'(\n)|( / )', t.display, flags=re.UNICODE):
-                self.lines.append(
-                    Unit(text=metadata,
-                         index=len(self.lines),
-                         unit_type='line'))
+                # If this token contains a newline or the Tesserae line delimiter,
+                # create a new line unit and append it for the next iteration.
+                if re.search(r'(\n)|( / )', t.display, flags=re.UNICODE):
+                    self.lines.append(
+                        Unit(text=metadata,
+                             index=len(self.lines),
+                             unit_type='line'))
 
-            # If this token contains a phrasee delimiter (one of .?!;:),
-            # create a new phrase unit and append it for the next iteration.
-            if phrase_delim and len(self.phrases[-1].tokens) > 0:
-                self.phrases.append(
-                    Unit(text=metadata,
-                         index=len(self.phrases),
-                         unit_type='phrase'))
+                # If this token contains a phrasee delimiter (one of .?!;:),
+                # create a new phrase unit and append it for the next iteration.
+                if phrase_delim and len(self.phrases[-1].tokens) > 0:
+                    self.phrases.append(
+                        Unit(text=metadata,
+                             index=len(self.phrases),
+                             unit_type='phrase'))
+            
+            if isinstance(t.feature_set, str):
+                self.lines[-1].tags.append(t.feature_set)
+                self.phrases[-1].tags.append(t.feature_set)
 
         if stop and len(self.lines[-1].tokens) == 0:
             self.lines.pop()

--- a/tesserae/utils/ingest.py
+++ b/tesserae/utils/ingest.py
@@ -1,54 +1,109 @@
 from tesserae.tokenizers import GreekTokenizer, LatinTokenizer
+
 from tesserae.unitizer import Unitizer
+
 from tesserae.utils import TessFile
 
 
+
+
+
 _tokenizers = {
+
     'greek': GreekTokenizer,
+
     'latin': LatinTokenizer,
+
 }
 
 
+
+
+
 def ingest_text(connection, text):
+
     """Update database with a new text
+
+
 
     ``text`` must not already exist in the database
 
+
+
     Parameters
+
     ----------
+
     connection : tesserae.db.TessMongoConnection
+
         A connection to the database
+
     text : tesserae.db.entities.Text
+
         The text to be ingested
 
+
+
     Returns
+
     -------
+
     ObjectId
+
         database identifier for the Text object just added
 
+
+
     Raises
+
     ------
+
     ValueError
+
         Raised when unknown language is encountered
 
+
+
     """
+
     if text.language not in _tokenizers:
+
         raise ValueError('Unknown language: {}'.format(text.language))
+
     tessfile = TessFile(text.path, metadata=text)
-    tokens, frequencies, feature_sets = \
+
+    print('Ingesting')
+
+    tokens, tags, frequencies, feature_sets = \
+
         _tokenizers[tessfile.metadata.language](connection).tokenize(
+
             tessfile.read(), text=tessfile.metadata)
+
     unitizer = Unitizer()
-    lines, phrases = unitizer.unitize(tokens, tessfile.metadata)
+
+    lines, phrases = unitizer.unitize(tokens, tags, tessfile.metadata)
+
+
 
     result = connection.insert(text)
+
     text_id = result.inserted_ids[0]
+
     if feature_sets:
+
         result = connection.insert(feature_sets)
+
     if frequencies:
+
         result = connection.insert(frequencies)
+
     if lines or phrases:
+
         result = connection.insert(lines + phrases)
+
     if tokens:
+
         result = connection.insert(tokens)
+
     return text_id

--- a/tesserae/utils/ingest.py
+++ b/tesserae/utils/ingest.py
@@ -1,109 +1,57 @@
 from tesserae.tokenizers import GreekTokenizer, LatinTokenizer
-
 from tesserae.unitizer import Unitizer
-
 from tesserae.utils import TessFile
 
 
-
-
-
 _tokenizers = {
-
     'greek': GreekTokenizer,
-
     'latin': LatinTokenizer,
-
 }
 
 
-
-
-
 def ingest_text(connection, text):
-
     """Update database with a new text
-
-
 
     ``text`` must not already exist in the database
 
-
-
     Parameters
-
     ----------
-
     connection : tesserae.db.TessMongoConnection
-
         A connection to the database
-
     text : tesserae.db.entities.Text
-
         The text to be ingested
 
-
-
     Returns
-
     -------
-
     ObjectId
-
         database identifier for the Text object just added
 
-
-
     Raises
-
     ------
-
     ValueError
-
         Raised when unknown language is encountered
-
-
-
     """
-
     if text.language not in _tokenizers:
-
         raise ValueError('Unknown language: {}'.format(text.language))
-
     tessfile = TessFile(text.path, metadata=text)
-
     print('Ingesting')
-
     tokens, tags, frequencies, feature_sets = \
-
         _tokenizers[tessfile.metadata.language](connection).tokenize(
-
             tessfile.read(), text=tessfile.metadata)
 
     unitizer = Unitizer()
-
     lines, phrases = unitizer.unitize(tokens, tags, tessfile.metadata)
 
-
-
     result = connection.insert(text)
-
     text_id = result.inserted_ids[0]
 
     if feature_sets:
-
         result = connection.insert(feature_sets)
-
     if frequencies:
-
         result = connection.insert(frequencies)
-
     if lines or phrases:
-
         result = connection.insert(lines + phrases)
-
     if tokens:
-
         result = connection.insert(tokens)
 
     return text_id


### PR DESCRIPTION
Added logic to extract location tags and assign them to units

- BaseTokenizer now captures the full <_author_ _work_ _location_> tag
- BaseTokenizer returns the list of tags in addition to tokens, feature sets, and frequencies from the tokenize() method
- Unitizer has logic to assign location tags to lines and phrases
- The Unit entity has a tags field for location tags
- General cleanup