### PR TITLE
Edited language paths for CLTK data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_data():
     home = str(Path.home())
     for lang, url in zip(langs, urls):
         try:
-            # Set up the file paths and directories for the Latin models
+            # Set up the file paths and directories for the language models
             base = os.path.join(home, 'cltk_data', lang, 'model')
             if not os.path.isdir(base):
                 os.makedirs(base, exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import os
 from setuptools import setup
 from setuptools.command.install import install
+from setuptools.command.develop import develop
 import shutil
 import sys
 import urllib.request
@@ -10,7 +11,7 @@ import zipfile
 
 class InstallLemmataModels(install):
     """Helper to install CLTK lemmatization models."""
-    description = "Install CLTK lemmatization models to $HOME/cltk_tools"
+    description = "Install CLTK lemmatization models to $HOME/cltk_data"
 
     def run(self):
         """Install CLTK lemmatization models.
@@ -23,7 +24,6 @@ class InstallLemmataModels(install):
         latin = 'https://github.com/cltk/lat_models_cltk/archive/master.zip'
         greek = 'https://github.com/cltk/grc_models_cltk/archive/master.zip'
         home = str(Path.home())
-
 
         try:
             # Set up the file paths and directories for the Latin models
@@ -67,6 +67,65 @@ class InstallLemmataModels(install):
         # Run the standard installer
         install.run(self)
 
+class DevelopLemmataModels(develop):
+    """Helper to install CLTK lemmatization models."""
+    description = "Install CLTK lemmatization models to $HOME/cltk_data"
+
+    def run(self):
+        """Install CLTK lemmatization models.
+
+        Tesserae uses the CLTK lemmatizers for each language, and these have
+        accompanying data that must be installed separately. This function
+        installs them to `$HOME/cltk_data` where they may be found by the
+        lemmatizer.
+        """
+        latin = 'https://github.com/cltk/lat_models_cltk/archive/master.zip'
+        greek = 'https://github.com/cltk/grc_models_cltk/archive/master.zip'
+        home = str(Path.home())
+
+        try:
+            # Set up the file paths and directories for the Latin models
+            base = os.path.join(home, 'cltk_data', 'lat', 'model')
+            if not os.path.isdir(base):
+                os.makedirs(base, exist_ok=True)
+
+            # Download the Latin models and move the ZIP archive
+            fname = os.path.join(base, 'lat_models_cltk.zip')
+            with urllib.request.urlopen(latin) as response, open(fname, 'wb') as out_file:
+                shutil.copyfileobj(response, out_file)
+
+            # Extract all files from the ZIP archive
+            with zipfile.ZipFile(fname, mode='r') as zf:
+                zf.extractall(base)
+
+            # Rename the extracted directory to match the expected name
+            fname, _ = os.path.splitext(fname)
+            os.rename(fname + '-master', fname)
+        except OSError:
+            pass
+
+        try:
+            # Repeat the process with Greek models
+            base = os.path.join(home, 'cltk_data', 'grc', 'model')
+            if not os.path.isdir(base):
+                os.makedirs(base, exist_ok=True)
+
+            fname = os.path.join(base, 'grc_models_cltk.zip')
+            with urllib.request.urlopen(greek) as response, open(fname, 'wb') as out_file:
+                shutil.copyfileobj(response, out_file)
+
+            with zipfile.ZipFile(fname, mode='r') as zf:
+                zf.extractall(base)
+
+            fname, _ = os.path.splitext(fname)
+            os.rename(fname + '-master', fname)
+        except OSError:
+            pass
+
+        # Run the standard installer
+        develop.run(self)
+
+
 
 setup(
     name='tesserae',
@@ -81,7 +140,8 @@ setup(
               'tesserae.db.entities',
               'tesserae.matchers',
               'tesserae.tokenizers',
-              'tesserae.utils'],
+              'tesserae.utils',
+    ],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Research',
@@ -105,5 +165,8 @@ setup(
         'scipy',
         'tqdm',
     ],
-    cmdclass={'install': InstallLemmataModels}
+    cmdclass={
+        'install': InstallLemmataModels,
+        'develop': DevelopLemmataModels,
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -20,18 +20,19 @@ class InstallLemmataModels(install):
         installs them to `$HOME/cltk_data` where they may be found by the
         lemmatizer.
         """
-        latin = 'https://github.com/cltk/latin_models_cltk/archive/master.zip'
-        greek = 'https://github.com/cltk/greek_models_cltk/archive/master.zip'
+        latin = 'https://github.com/cltk/lat_models_cltk/archive/master.zip'
+        greek = 'https://github.com/cltk/grc_models_cltk/archive/master.zip'
         home = str(Path.home())
+
 
         try:
             # Set up the file paths and directories for the Latin models
-            base = os.path.join(home, 'cltk_data', 'latin', 'model')
+            base = os.path.join(home, 'cltk_data', 'lat', 'model')
             if not os.path.isdir(base):
                 os.makedirs(base, exist_ok=True)
 
             # Download the Latin models and move the ZIP archive
-            fname = os.path.join(base, 'latin_models_cltk.zip')
+            fname = os.path.join(base, 'lat_models_cltk.zip')
             with urllib.request.urlopen(latin) as response, open(fname, 'wb') as out_file:
                 shutil.copyfileobj(response, out_file)
 
@@ -47,11 +48,11 @@ class InstallLemmataModels(install):
 
         try:
             # Repeat the process with Greek models
-            base = os.path.join(home, 'cltk_data', 'greek', 'model')
+            base = os.path.join(home, 'cltk_data', 'grc', 'model')
             if not os.path.isdir(base):
                 os.makedirs(base, exist_ok=True)
 
-            fname = os.path.join(base, 'greek_models_cltk.zip')
+            fname = os.path.join(base, 'grc_models_cltk.zip')
             with urllib.request.urlopen(greek) as response, open(fname, 'wb') as out_file:
                 shutil.copyfileobj(response, out_file)
 

--- a/setup.py
+++ b/setup.py
@@ -9,31 +9,29 @@ import urllib.request
 import zipfile
 
 
-class InstallLemmataModels(install):
-    """Helper to install CLTK lemmatization models."""
-    description = "Install CLTK lemmatization models to $HOME/cltk_data"
-
-    def run(self):
-        """Install CLTK lemmatization models.
+def get_data():
+    """Install CLTK lemmatization models.
 
         Tesserae uses the CLTK lemmatizers for each language, and these have
         accompanying data that must be installed separately. This function
         installs them to `$HOME/cltk_data` where they may be found by the
         lemmatizer.
         """
-        latin = 'https://github.com/cltk/lat_models_cltk/archive/master.zip'
-        greek = 'https://github.com/cltk/grc_models_cltk/archive/master.zip'
-        home = str(Path.home())
-
+    langs = ['lat', 'grc']
+    urls = ['https://github.com/cltk/lat_models_cltk/archive/master.zip',
+            'https://github.com/cltk/grc_models_cltk/archive/master.zip',
+    ]
+    home = str(Path.home())
+    for lang, url in zip(langs, urls):
         try:
             # Set up the file paths and directories for the Latin models
-            base = os.path.join(home, 'cltk_data', 'lat', 'model')
+            base = os.path.join(home, 'cltk_data', lang, 'model')
             if not os.path.isdir(base):
                 os.makedirs(base, exist_ok=True)
 
             # Download the Latin models and move the ZIP archive
-            fname = os.path.join(base, 'lat_models_cltk.zip')
-            with urllib.request.urlopen(latin) as response, open(fname, 'wb') as out_file:
+            fname = os.path.join(base, lang + '_models_cltk.zip')
+            with urllib.request.urlopen(url) as response, open(fname, 'wb') as out_file:
                 shutil.copyfileobj(response, out_file)
 
             # Extract all files from the ZIP archive
@@ -46,24 +44,13 @@ class InstallLemmataModels(install):
         except OSError:
             pass
 
-        try:
-            # Repeat the process with Greek models
-            base = os.path.join(home, 'cltk_data', 'grc', 'model')
-            if not os.path.isdir(base):
-                os.makedirs(base, exist_ok=True)
 
-            fname = os.path.join(base, 'grc_models_cltk.zip')
-            with urllib.request.urlopen(greek) as response, open(fname, 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
+class InstallLemmataModels(install):
+    """Helper to install CLTK lemmatization models."""
+    description = "Install CLTK lemmatization models to $HOME/cltk_data"
 
-            with zipfile.ZipFile(fname, mode='r') as zf:
-                zf.extractall(base)
-
-            fname, _ = os.path.splitext(fname)
-            os.rename(fname + '-master', fname)
-        except OSError:
-            pass
-
+    def run(self):
+        get_data()
         # Run the standard installer
         install.run(self)
 
@@ -72,59 +59,9 @@ class DevelopLemmataModels(develop):
     description = "Install CLTK lemmatization models to $HOME/cltk_data"
 
     def run(self):
-        """Install CLTK lemmatization models.
-
-        Tesserae uses the CLTK lemmatizers for each language, and these have
-        accompanying data that must be installed separately. This function
-        installs them to `$HOME/cltk_data` where they may be found by the
-        lemmatizer.
-        """
-        latin = 'https://github.com/cltk/lat_models_cltk/archive/master.zip'
-        greek = 'https://github.com/cltk/grc_models_cltk/archive/master.zip'
-        home = str(Path.home())
-
-        try:
-            # Set up the file paths and directories for the Latin models
-            base = os.path.join(home, 'cltk_data', 'lat', 'model')
-            if not os.path.isdir(base):
-                os.makedirs(base, exist_ok=True)
-
-            # Download the Latin models and move the ZIP archive
-            fname = os.path.join(base, 'lat_models_cltk.zip')
-            with urllib.request.urlopen(latin) as response, open(fname, 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
-
-            # Extract all files from the ZIP archive
-            with zipfile.ZipFile(fname, mode='r') as zf:
-                zf.extractall(base)
-
-            # Rename the extracted directory to match the expected name
-            fname, _ = os.path.splitext(fname)
-            os.rename(fname + '-master', fname)
-        except OSError:
-            pass
-
-        try:
-            # Repeat the process with Greek models
-            base = os.path.join(home, 'cltk_data', 'grc', 'model')
-            if not os.path.isdir(base):
-                os.makedirs(base, exist_ok=True)
-
-            fname = os.path.join(base, 'grc_models_cltk.zip')
-            with urllib.request.urlopen(greek) as response, open(fname, 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
-
-            with zipfile.ZipFile(fname, mode='r') as zf:
-                zf.extractall(base)
-
-            fname, _ = os.path.splitext(fname)
-            os.rename(fname + '-master', fname)
-        except OSError:
-            pass
-
-        # Run the standard installer
+        get_data()
+        # Run the developer installer
         develop.run(self)
-
 
 
 setup(

--- a/tesserae/tokenizers/greek.py
+++ b/tesserae/tokenizers/greek.py
@@ -35,7 +35,7 @@ class GreekTokenizer(BaseTokenizer):
             self.sigma_alt,
             r"])"])
 
-        self.lemmatizer = Lemmata('lemmata', 'greek')
+        self.lemmatizer = Lemmata('lemmata', 'grc')
 
     def normalize(self, raw, split=True):
         """Normalize a single Greek word.

--- a/tesserae/tokenizers/latin.py
+++ b/tesserae/tokenizers/latin.py
@@ -15,7 +15,7 @@ class LatinTokenizer(BaseTokenizer):
 
         # Set up patterns that will be reused
         self.jv_replacer = JVReplacer()
-        self.lemmatizer = Lemmata('lemmata', 'latin')
+        self.lemmatizer = Lemmata('lemmata', 'lat')
 
         self.split_pattern = \
             '( / )|([\\s]+)|([^\\w' + self.diacriticals + ']+)'


### PR DESCRIPTION
CLTK has updated their naming schema to use ISO 639-2 language codes (i.e., 'latin' is now 'lat' and 'greek' is now 'grc'). These references have been updated to reflect the current schema.