### PR TITLE
Results exports

### DIFF
--- a/tesserae/cli/export.py
+++ b/tesserae/cli/export.py
@@ -1,8 +1,10 @@
 import argparse
 import getpass
 
-from tesserae.db import TessMongoConnection
+from bson.objectid import ObjectId
 
+from tesserae.db import TessMongoConnection
+from tesserae.utils.exports import export
 
 def parse_args(args=None):
     p = argparse.ArgumentParser(
@@ -62,29 +64,25 @@ def parse_args(args=None):
     return p.parse_args(args)
 
 
-def main(connection, search_id, format, filepath=None, delimiter=','):
-    if format == 'json':
-        from tesserae.utils.exports.json import dump, dumps
-        args = (connection, search_id)
-        if filepath:
-            args = args + (filepath,)
-    elif format == 'xml':
-        from tesserae.utils.exports.xml import dump, dumps
-        args = (connection, search_id)
-        if filepath:
-            args = args + (filepath,)
-    else:
-        from tesserae.utils.exports.csv import dump, dumps
-        args = (connection, search_id)
-        if filepath:
-            args = args + (filepath,)
-        args = args + (delimiter,)
+def main(connection, search_id, file_format, filepath=None, delimiter=','):
+    """Export a search to file or screen.
 
-
-    if filepath:
-        dump(*args)
-    else:
-        print(dumps(*args))
+    Parameters
+    ----------
+    connection : tesserae.db.TessMongoConnection
+        Connection to the Tesserae database.
+    search_id : bson.objectid.ObjectId
+        Database id of the search to run.
+    format : str
+        The file format to dump.
+    filepath : str, optional
+        The file to write. If not provided, the contents will be written to
+        `sys.stdout`.
+    delimiter : str, optional
+        The column delimiter for CSV-like files. Only used when ``format``
+        is 'csv'.
+    """
+    export(connection, search_id, file_format, filepath=None, delimiter=',')
 
 
 if __name__ == '__main__':
@@ -96,4 +94,7 @@ if __name__ == '__main__':
 
     connection = TessMongoConnection(
         args.host, args.port, args.user, password, db=args.database)
-    main(connection, args.search, args.format, filepath=args.path)
+
+    search_id = ObjectId(args.search)
+
+    main(connection, search_id, args.format, filepath=args.path)

--- a/tesserae/cli/export.py
+++ b/tesserae/cli/export.py
@@ -51,7 +51,7 @@ def parse_args(args=None):
         help='output format')
     text.add_argument(
         '--path',
-        type='str',
+        type=str,
         help='path to write export to (standard out if not supplied)')
     text.add_argument(
         '--delimiter',

--- a/tesserae/cli/export.py
+++ b/tesserae/cli/export.py
@@ -90,7 +90,7 @@ def main(connection, search_id, format, filepath=None, delimiter=','):
 if __name__ == '__main__':
     args = parse_args()
     if args.password:
-        password = getpass(prompt='Tesserae MongoDB Password: ')
+        password = getpass.getpass(prompt='Tesserae MongoDB Password: ')
     else:
         password = None
 

--- a/tesserae/cli/export.py
+++ b/tesserae/cli/export.py
@@ -96,4 +96,4 @@ if __name__ == '__main__':
 
     connection = TessMongoConnection(
         args.host, args.port, args.user, password, db=args.database)
-    main(connection, args.search_id, args.format, filepath=args.path)
+    main(connection, args.search, args.format, filepath=args.path)

--- a/tesserae/cli/export.py
+++ b/tesserae/cli/export.py
@@ -1,0 +1,99 @@
+import argparse
+import getpass
+
+from tesserae.db import TessMongoConnection
+
+
+def parse_args(args=None):
+    p = argparse.ArgumentParser(
+        prog='tesserae_ingest',
+        description='Ingest a text into the Tesserae database.')
+
+    db = p.add_argument_group(
+        title='database',
+        description='database connection details')
+    text = p.add_argument_group(
+        title='text',
+        description='text metadata')
+
+    db.add_argument(
+        '--user',
+        type=str,
+        help='user to access the database as')
+    db.add_argument(
+        '--password',
+        action='store_true',
+        help='pass to be prompted for a database password')
+    db.add_argument(
+        '--host',
+        type=str,
+        default='127.0.0.1',
+        help='the host name or IP address of the MongoDB database')
+    db.add_argument(
+        '--port',
+        type=str,
+        default=27017,
+        help='the port that the database listens on')
+    db.add_argument(
+        '--database',
+        type=str,
+        default='tesserae',
+        help='the name of the database to access')
+
+    text.add_argument(
+        '--search',
+        type=str,
+        help='database search ID to serialize')
+    text.add_argument(
+        '--format',
+        choices=['csv', 'json', 'xml'],
+        default='csv',
+        help='output format')
+    text.add_argument(
+        '--path',
+        type='str',
+        help='path to write export to (standard out if not supplied)')
+    text.add_argument(
+        '--delimiter',
+        type=str,
+        default=',',
+        help='CSV row item delimiting character')
+
+    return p.parse_args(args)
+
+
+def main(connection, search_id, format, filepath=None, delimiter=','):
+    if format == 'json':
+        from tesserae.utils.exports.json import dump, dumps
+        args = (connection, search_id)
+        if filepath:
+            args = args + (filepath,)
+    elif format == 'xml':
+        from tesserae.utils.exports.xml import dump, dumps
+        args = (connection, search_id)
+        if filepath:
+            args = args + (filepath,)
+    else:
+        from tesserae.utils.exports.csv import dump, dumps
+        args = (connection, search_id)
+        if filepath:
+            args = args + (filepath,)
+        args = args + (delimiter,)
+
+
+    if filepath:
+        dump(*args)
+    else:
+        print(dumps(*args))
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    if args.password:
+        password = getpass(prompt='Tesserae MongoDB Password: ')
+    else:
+        password = None
+
+    connection = TessMongoConnection(
+        args.host, args.port, args.user, password, db=args.database)
+    main(connection, args.search_id, args.format, filepath=args.path)

--- a/tesserae/utils/exports/__init__.py
+++ b/tesserae/utils/exports/__init__.py
@@ -167,7 +167,7 @@ def dumps(connection, search_id, file_format, delimiter=','):
     return exporter.dumps(*args, **kwargs)
 
 
-def export(connection, search_id, file_format, filename=None, delimiter=','):
+def export(connection, search_id, file_format, filepath=None, delimiter=','):
     """Dump a Tesserae search to stdout.
 
     Parameters
@@ -178,20 +178,25 @@ def export(connection, search_id, file_format, filename=None, delimiter=','):
         The database id of the search to serialize.
     file_format : {'csv','json','xml'}
         The format to export.
-    filename : str, optional
-        Path to the output file. If not provided, the export is written to
-        `sys.stdout`.
+    filepath : str, optional
+        Path to the output file. If not provided, the export is returned as
+        a string.
     delimiter : str, optional
         The row iterm separator. Only used when ``file_format`` is 'csv'.
         Default: ','.
+
+    Returns
+    -------
+    results : str
+        The string with the results formatted by ``file_format`` and
+        ``delimiter`` if applicable. Only returned if ``filepath`` is not
+        provided.
     """
     if file_format:
-        dump(connection, search_id, file_format, filename,
+        dump(connection, search_id, file_format, filepath,
              delimiter=delimiter)
     else:
-        print(dumps(connection, search_id, file_format, delimiter=delimiter))
-
-
+        return dumps(connection, search_id, file_format, delimiter=delimiter)
 
 
 __all__ = ['dump', 'dumps', 'export']

--- a/tesserae/utils/exports/__init__.py
+++ b/tesserae/utils/exports/__init__.py
@@ -1,0 +1,197 @@
+"""Utilities for exporting search results to different file formats.
+
+Modules
+-------
+csv
+json
+highlight
+xml
+
+Functions
+---------
+dump
+dumps
+"""
+import importlib
+import math
+
+from tesserae.db.entities import Search, Text
+
+
+def get_exporter(file_format):
+    """Get the correct exporter for the file type.
+    
+    Parameters
+    ----------
+    file_format : {'csv','json','xml'}
+        The format to export.
+
+    Returns
+    -------
+    exporter : module
+        The exporter to use, with ``dump`` and ``dumps`` functions defined.
+    
+    Raises
+    ------
+    ValueError
+        Raised when no exporter exists for ``file_format``.
+    """
+    # Dynamically import the exporter based on the filename. This keeps the
+    # imported modules low and prevents collisions.
+    try:
+        exporter = importlib.import_module(
+            f'tesserae.utils.export.{file_format.lower()}')
+    except ImportError:
+        msg = f'''Invalid file format "{file_format}" supplied.
+                  Must be one of ["csv", "json", or "xml"]'''
+        raise ValueError(msg)
+    
+    return exporter
+
+
+def retrieve_search(connection, search_id):
+    """Pull search data from the database.
+
+    Parameters
+    ----------
+    connection : tesserae.db.TessMongoConnection
+        Connection to the MongoDB instance.
+    search_id : str or `bson.objectid.ObjectID`
+        The database id of the search to serialize.
+
+    Returns
+    -------
+    search : `tesserae.db.entities.Search`
+        Search metadata.
+    source : `tesserae.db.entities.Text`
+    target : `tesserae.db.entities.Text`
+        Source and target text metadata.
+    
+    Raises
+    ------
+    ValueError
+        Raised when ``search``, ``source``, or ``target`` cannot be found in
+        the database.
+    RuntimeError
+        Raised when ``search`` is not complete.
+    """
+    # Pull the search and text data from the database.
+    try:
+        search = connection.find(Search.collection, id=search_id)[0]
+    except IndexError:
+        raise ValueError(f'No search with id {search_id} found.')
+
+    if search.status.lower() != 'done':
+        msg = ''.join([
+            f'Search {search_id} is still in-progress.',
+            'Try again in a few minutes.'
+        ])
+        raise RuntimeError(msg)
+    
+    try:
+        source_id = search.parameters['source']['object_id']
+        source = connection.find(Text.collection, id=source_id)[0]
+    except IndexError:
+        msg = ''.join([
+            f'No source text with id {source_id} found.',
+            'Was the text deleted?'
+        ])
+        raise ValueError(msg)
+    
+    try:
+        target_id = search.parameters['target']['object_id']
+        target = connection.find(Text.collection, id=target_id)[0]
+    except IndexError:
+        msg = ''.join([
+            f'No target text with id {target_id} found.',
+            'Was the text deleted?'
+        ])
+        raise ValueError(msg)
+
+    return search, source, target
+
+
+def dump(connection, search_id, file_format, filename, delimiter=','):
+    """Dump a Tesserae search to file.
+
+    Parameters
+    ----------
+    connection : tesserae.db.TessMongoConnection
+        Connection to the MongoDB instance.
+    search_id : str or `bson.objectid.ObjectID`
+        The database id of the search to serialize.
+    file_format : {'csv','json','xml'}
+        The format to export.
+    filename : str
+        Path to the output file.
+    delimiter : str, optional
+        The row iterm separator. Only used when ``file_format`` is 'csv'.
+        Default: ','.
+    """
+    exporter = get_exporter(file_format)
+
+    search, source, target = retrieve_search(connection, search_id)
+
+    args = (filename, connection, search, source, target)
+    kwargs = {}
+    if file_format.lower() == 'csv':
+        kwargs['delimiter'] = delimiter
+
+    exporter.dump(*args, **kwargs)
+
+
+def dumps(connection, search_id, file_format, delimiter=','):
+    """Dump a Tesserae search to stdout.
+
+    Parameters
+    ----------
+    connection : tesserae.db.TessMongoConnection
+        Connection to the MongoDB instance.
+    search_id : str or `bson.objectid.ObjectID`
+        The database id of the search to serialize.
+    file_format : {'csv','json','xml'}
+        The format to export.
+    delimiter : str, optional
+        The row iterm separator. Only used when ``file_format`` is 'csv'.
+        Default: ','.
+    """
+    exporter = get_exporter(file_format)
+
+    search, source, target = retrieve_search(connection, search_id)
+
+    args = (connection, search, source, target)
+    kwargs = {}
+    if file_format.lower() == 'csv':
+        kwargs['delimiter'] = delimiter
+
+    return exporter.dumps(*args, **kwargs)
+
+
+def export(connection, search_id, file_format, filename=None, delimiter=','):
+    """Dump a Tesserae search to stdout.
+
+    Parameters
+    ----------
+    connection : tesserae.db.TessMongoConnection
+        Connection to the MongoDB instance.
+    search_id : str or `bson.objectid.ObjectID`
+        The database id of the search to serialize.
+    file_format : {'csv','json','xml'}
+        The format to export.
+    filename : str, optional
+        Path to the output file. If not provided, the export is written to
+        `sys.stdout`.
+    delimiter : str, optional
+        The row iterm separator. Only used when ``file_format`` is 'csv'.
+        Default: ','.
+    """
+    if file_format:
+        dump(connection, search_id, file_format, filename,
+             delimiter=delimiter)
+    else:
+        print(dumps(connection, search_id, file_format, delimiter=delimiter))
+
+
+
+
+__all__ = ['dump', 'dumps', 'export']

--- a/tesserae/utils/exports/__init__.py
+++ b/tesserae/utils/exports/__init__.py
@@ -15,6 +15,8 @@ dumps
 import importlib
 import math
 
+from bson.objectid import ObjectId
+
 from tesserae.db.entities import Search, Text
 
 
@@ -75,6 +77,9 @@ def retrieve_search(connection, search_id):
     RuntimeError
         Raised when ``search`` is not complete.
     """
+    if isinstance(search_id, str):
+        search_id = ObjectId(search_id)
+    
     # Pull the search and text data from the database.
     try:
         search = connection.find(Search.collection, id=search_id)[0]
@@ -128,6 +133,9 @@ def dump(connection, search_id, file_format, filename, delimiter=','):
         The row iterm separator. Only used when ``file_format`` is 'csv'.
         Default: ','.
     """
+    if isinstance(search_id, str):
+        search_id = ObjectId(search_id)
+    
     exporter = get_exporter(file_format)
 
     search, source, target = retrieve_search(connection, search_id)
@@ -155,6 +163,9 @@ def dumps(connection, search_id, file_format, delimiter=','):
         The row iterm separator. Only used when ``file_format`` is 'csv'.
         Default: ','.
     """
+    if isinstance(search_id, str):
+        search_id = ObjectId(search_id)
+    
     exporter = get_exporter(file_format)
 
     search, source, target = retrieve_search(connection, search_id)
@@ -192,6 +203,9 @@ def export(connection, search_id, file_format, filepath=None, delimiter=','):
         ``delimiter`` if applicable. Only returned if ``filepath`` is not
         provided.
     """
+    if isinstance(search_id, str):
+        search_id = ObjectId(search_id)
+    
     if file_format:
         dump(connection, search_id, file_format, filepath,
              delimiter=delimiter)

--- a/tesserae/utils/exports/csv.py
+++ b/tesserae/utils/exports/csv.py
@@ -40,12 +40,12 @@ def build(connection, search_id, stream, delimiter=','):
       The same object passed to ``stream``.
   """
   # Pull the search and text data from the database.
-  search = connection.find(Search.collection, id=search_id)
+  search = connection.find(Search.collection, id=search_id)[0]
   results = connection.find(Match.collection, search_id=search_id)
   source = connection.find(Text.collection,
-                           id=search.parameters['source']['object_id'])
+                           id=search.parameters['source']['object_id'])[0]
   target = connection.find(Text.collection,
-                           id=search.parameters['target']['object_id'])
+                           id=search.parameters['target']['object_id'])[0]
   
   # Sort the search results by score and get the max and min scores.
   results.sort(key=lambda x: x.score, reverse=True)

--- a/tesserae/utils/exports/csv.py
+++ b/tesserae/utils/exports/csv.py
@@ -1,0 +1,168 @@
+"""Tools for exporting searches in CSV format.
+
+Functions
+---------
+build
+  Construct CSV from a completed Tesserae search.
+dump
+  Dump a Tesserae search to file as CSV.
+dumps
+  Dump a Tesserae search to a CSV string.
+format_result
+  Convert a search result into a CSV row.
+"""
+import csv
+import io
+import itertools
+import math
+
+from tesserae.db.entities import Match, Search, Text, Unit
+from tesserae.utils.exports.highlight import highlight_matches
+
+
+def build(connection, search_id, stream, delimiter=','):
+  """Construct CSV from a completed Tesserae search.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  stream : io.TextIOBase
+    Text stream to write to, usually a string or file stream
+  delimiter : str, optional
+    The row iterm separator. Default: ','.
+  
+  Returns
+  -------
+    stream : io.TextIOBase
+      The same object passed to ``stream``.
+  """
+  # Pull the search and text data from the database.
+  search = connection.find(Search.collection, id=search_id)
+  results = connection.find(Match.collection, search_id=search_id)
+  source = connection.find(Text.collection,
+                           id=search.parameters['source']['object_id'])
+  target = connection.find(Text.collection,
+                           id=search.parameters['target']['object_id'])
+  
+  # Sort the search results by score and get the max and min scores.
+  results.sort(key=lambda x: x.score, reverse=True)
+  max_score = max(results[0].score, 10)
+  min_score = int(math.floor(results[-1].score))
+
+  # The search parameters and metadata are written as comments to the top of
+  # the CSV stream.
+  comments = [
+    f'# Tesserae V5 Results',
+    f'#',
+    f'# session\t= {search_id}',
+    f'# source\t= {source.author}.{source.title.lower().replace(" ", "_")}',
+    f'# target\t= {target.author}.{target.title.lower().replace(" ", "_")}',
+    f'# unit\t= {search.parameters["source"]["unit"]}',
+    f'# feature\t= {search.parameters["method"]["feature"]}',
+    f'# stopsize\t= {len(search.parameters["method"]["stopwords"])}',
+    f'# stbasis\t= ',
+    f'# stopwords\t= {search.parameters["method"]["stopwords"]}',
+    f'# max_dist\t= {search.parameters["method"]["max_distance"]}',
+    f'# dibasis\t= {search.parameters["method"]["distance_basis"]}',
+    f'# cutoff\t= {min_score}',
+    f'# filter\t= off',
+  ]
+
+  stream.write('\n'.join(comments))
+
+  # Add CSV rows to the stream from dictionary versions of the results.
+  # Row headers are passed in the second argument.
+  writer = csv.DictWriter(
+    stream,
+    ["Result", "Target_Loc", "Target_Txt",
+     "Source_Loc", "Source_Txt", "Shared",
+     "Score", "Raw_Score"],
+    delimiter=delimiter
+  )
+  writer.writeheader()
+
+  # Convert each result to a dict with keys corresponding to the headers
+  # passed to ``writer``.
+  results = zip(results,
+                range(1, len(results) + 1),
+                itertools.repeat(max_score, len(results)))
+  writer.writerows(itertools.starmap(format_result, results))
+  
+  return stream
+
+
+def dump(connection, search_id, filepath, delimiter=','):
+  """Dump a Tesserae search to file as CSV.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  filepath : str
+    Path to the output CSV file.
+  delimiter : str, optional
+    The row iterm separator. Default: ','.
+  """
+  with open(filepath, 'w') as f:
+    build(connection, search_id, f, delimiter=delimiter)
+
+
+def dumps(connections, search_id, delimiter):
+  """Dump a Tesserae search to an CSV string.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  delimiter : str, optional
+    The row iterm separator. Default: ','.
+  
+  Returns
+  -------
+    out : str
+      CSV string with search metadata and results.
+  """
+  output = io.StringIO()
+  build(connections, search_id, output, delimiter=delimiter)
+  return output.getvalue()
+
+
+def format_result(match, idx, max_score):
+  """Convert a search result into a CSV row.
+
+  Parameters
+  ----------
+  match : tesserae.db.entities.Match
+    The result to serialize.
+  idx : int
+    The row number of this result.
+  max_score : float
+    The max observed score in the search. Required for normalization.
+  
+  Returns
+  -------
+  obj : dict
+    The result converted into a CSV DictWriter compatible format.
+  """
+  source_txt = highlight_matches(match.source_snippet,
+                                 [i[0] for i in match.highlight])
+  target_txt = highlight_matches(match.target_snippet,
+                                 [i[1] for i in match.highlight])
+  features = '; '.join(match.matched_features)
+  return {
+    'Result': f'{idx}',
+    'Target_Loc': f'\"{match.target_tag}\"',
+    'Target_Txt': f'\"{target_txt}\"',
+    'Source_Loc': f'\"{match.source_tag}\"',
+    'Source_Txt': f'\"{source_txt}\"',
+    'Shared': f'\"{features}\"',
+    'Score': f'{match.score * 10 / max_score}',
+    'Raw_Score': f'{match.score}'
+  }

--- a/tesserae/utils/exports/highlight.py
+++ b/tesserae/utils/exports/highlight.py
@@ -1,0 +1,74 @@
+"""Tools for highlighting match words in units.
+
+Functions
+---------
+highlight_matches
+  Highlight match tokens in a search result.
+"""
+import re
+
+
+def highlight_matches(snippet, match_indices, markup='**'):
+  """Highlight match tokens in a search result.
+
+  Tesserae file dumps preserve match token highlighting in the raw unit text.
+  Given a snippet and match token indices, wraps the tokens at the indices
+  with markup to highlight it. Token characters include only alphabetic and
+  diacritical ASCII and UTF-8 characters.
+
+  Parameters
+  ----------
+  snippet : str
+    The raw text of the match unit to highlight.
+  match_indices : sequence of int
+    The indices of tokens to highlight.
+  markup : str or tuple of str, optional
+    Markup to apply to wrap match tokens in. If a string, the string is placed
+    on both sides of the token. If a tuple, the 0th element is placed at the
+    start and 1st element is placed at the end.
+  
+  Returns
+  -------
+  highlighted : str
+    A copy of ``snippet`` with the metch tokens highlighted by ``markup``.
+
+  Examples
+  --------
+  >>> highlight_matches('foo !bar, baz-quux.', [1, 3])
+  'foo !**bar**, baz-**quux**.'
+  >>> highlight_matches('foo !bar, baz-quux', [1, 3], markup='@')
+  'foo !@bar@, baz-@quux@'
+  >>> highlight_matches('foo !bar, baz-quux', [1, 3], markup=('<b>', '</b>'))
+  'foo !<b>bar</b>, baz-<b>quux</b>'
+  """
+  if isinstance(markup, str):
+    markup = (markup, markup)
+
+  if not match_indices or markup[0] == '':
+    return snippet
+  elif isinstance(match_indices, int):
+    match_indices = [match_indices]
+
+  match_indices.sort()
+  highlighted = []
+
+  # Split between word- and non-word tokens but only count the word tokens
+  # when evaluating the match indices.
+  tokens = re.split(r'([\s\d.!,;?-&]+)', snippet, flags=re.UNICODE)
+  tidx = 0
+  midx = match_indices.pop(0)
+
+  # If looking at a word token, highlight it if it is in the position of the
+  # next match token and pull the next match index. Always increment the word
+  # token counter. Otherwise, append the token unaltered.
+  for i, t in enumerate(tokens):
+    if re.search(r'[\w]+', t):
+      highlighted.append(f'{markup[0]}{t}{markup[1]}' if midx == tidx else t)
+      midx = match_indices.pop(0) if midx == tidx else midx
+      tidx += 1
+    else:
+      highlighted.append(t)
+  
+  # Spaces and punctuation should be preserved in non-word tokens, so join on
+  # the empty string to recreate the snippet on with highlights.
+  return ''.join(highlighted)

--- a/tesserae/utils/exports/json.py
+++ b/tesserae/utils/exports/json.py
@@ -1,0 +1,124 @@
+"""Tools for exporting searches as JSON objects.
+
+Functions
+---------
+build
+  Construct a JSON object from a completed Tesserae search.
+dump
+  Dump a Tesserae search to file as JSON.
+dumps
+  Dump a Tesserae search to a JSON string.
+format_result
+  Convert a search result into a JSON object.
+"""
+import itertools
+import json
+import math
+
+from tesserae.db.entities import Match, Search, Text, Unit
+from tesserae.utils.exports.highlight import highlight_matches
+
+
+def build(connection, search_id):
+  """Construct a JSON object from a completed Tesserae search.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  
+  Returns
+  -------
+    obj : dict
+      JSON-compatible dictionary with search metadata and results.
+  """
+  search = connection.find(Search.collection, id=search_id)
+  results = connection.find(Match.collection, search_id=search_id)
+  source = connection.find(Text.collection,
+                           id=search.parameters['source']['object_id'])
+  target = connection.find(Text.collection,
+                           id=search.parameters['target']['object_id'])
+  
+  results.sort(key=lambda x: x.score, reverse=True)
+  max_score = max(results[0].score, 10)
+  min_score = int(math.floor(results[-1].score))
+
+  out = search.json_encode()
+  out['parameters']['source'].update(source.json_encode())
+  out['parameters']['target'].update(target.json_encode())
+  out['results'] = list(
+    itertools.starmap(
+      format_result, 
+      zip(results, itertools.repeat(max_score, len(results)))
+    )
+  )
+  del out['results_id']
+  del out['progress']
+  del out['status']
+  del out['msg']
+  
+  return out
+
+
+def dump(connection, search_id, filepath):
+  """Dump a Tesserae search to file as JSON.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  filepath : str
+    Path to the output JSON file.
+  """
+  out = build(connection, search_id)
+  with open(filepath, 'w') as f:
+    json.dump(out, f)
+
+
+def dumps(connection, search_id):
+  """Dump a Tesserae search to a JSON string.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  
+  Returns
+  -------
+    obj : str
+      JSON string with search metadata and results.
+  """
+  out = build(connection, search_id)
+  return json.dumps(out)
+
+
+def format_result(match, max_score):
+  """Convert a search result into a JSON object.
+
+  Parameters
+  ----------
+  match : tesserae.db.entities.Match
+    The result to serialize.
+  max_score : float
+    The max observed score in the search. Required for normalization.
+
+  Returns
+  -------
+  obj : dict
+    The result as a JSON-compatible dictionary.
+  """
+  out = match.json_encode()
+  out['result_id'] = out['_id']
+  del out['_id']
+  out['source_snippet'] = highlight_matches(out['source_snippet'], [i[0] for i in match.match_indices])
+  out['target_snippet'] = highlight_matches(out['target_snippet'], [i[1] for i in match.match_indices])
+  del out['match_indices']
+  out['score'] = match.score * 10 / max_score
+  out['raw_score'] = match.score
+  return out

--- a/tesserae/utils/exports/json.py
+++ b/tesserae/utils/exports/json.py
@@ -15,45 +15,43 @@ import itertools
 import json
 import math
 
-from tesserae.db.entities import Match, Search, Text, Unit
 from tesserae.utils.exports.highlight import highlight_matches
+from tesserae.utils.paging import Pager
+from tesserae.utils.search import get_max_score
 
 
-def build(connection, search_id):
+def build(connection, search, source, target):
   """Construct a JSON object from a completed Tesserae search.
 
   Parameters
   ----------
   connection : tesserae.db.TessMongoConnection
     Connection to the MongoDB instance.
-  search_id : str or `bson.objectid.ObjectID`
-    The database id of the search to serialize.
+  search : `tesserae.db.entities.Search`
+    Search metadata.
+  source : `tesserae.db.entities.Text`
+  target : `tesserae.db.entities.Text`
+    Source and target text data.
   
   Returns
   -------
     obj : dict
       JSON-compatible dictionary with search metadata and results.
   """
-  search = connection.find(Search.collection, id=search_id)[0]
-  results = connection.find(Match.collection, search_id=search_id)
-  source = connection.find(Text.collection,
-                           id=search.parameters['source']['object_id'])[0]
-  target = connection.find(Text.collection,
-                           id=search.parameters['target']['object_id'])[0]
-  
-  results.sort(key=lambda x: x.score, reverse=True)
-  max_score = max(results[0].score, 10)
-  min_score = int(math.floor(results[-1].score))
+  max_score = get_max_score(connection, search.id)
+  pages = Pager(connection, search.id)
 
   out = search.json_encode()
   out['parameters']['source'].update(source.json_encode())
   out['parameters']['target'].update(target.json_encode())
-  out['results'] = list(
-    itertools.starmap(
-      format_result, 
-      zip(results, itertools.repeat(max_score, len(results)))
+  out['results'] = []
+  for page in pages:
+    out['results'].extend(
+      itertools.starmap(
+        format_result, 
+        zip(page, itertools.repeat(max_score, len(page)))
+      )
     )
-  )
   del out['results_id']
   del out['progress']
   del out['status']
@@ -62,39 +60,45 @@ def build(connection, search_id):
   return out
 
 
-def dump(connection, search_id, filepath):
+def dump(filepath, connection, search, source, target):
   """Dump a Tesserae search to file as JSON.
 
   Parameters
   ----------
-  connection : tesserae.db.TessMongoConnection
-    Connection to the MongoDB instance.
-  search_id : str or `bson.objectid.ObjectID`
-    The database id of the search to serialize.
   filepath : str
     Path to the output JSON file.
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search : `tesserae.db.entities.Search`
+    Search metadata.
+  source : `tesserae.db.entities.Text`
+  target : `tesserae.db.entities.Text`
+    Source and target text data.
   """
-  out = build(connection, search_id)
+  out = build(connection, search, source, target)
   with open(filepath, 'w') as f:
     json.dump(out, f)
 
 
-def dumps(connection, search_id):
+def dumps(connection, search, source, target):
   """Dump a Tesserae search to a JSON string.
 
   Parameters
   ----------
   connection : tesserae.db.TessMongoConnection
     Connection to the MongoDB instance.
-  search_id : str or `bson.objectid.ObjectID`
-    The database id of the search to serialize.
+  search : `tesserae.db.entities.Search`
+    Search metadata.
+  source : `tesserae.db.entities.Text`
+  target : `tesserae.db.entities.Text`
+    Source and target text data.
   
   Returns
   -------
     obj : str
       JSON string with search metadata and results.
   """
-  out = build(connection, search_id)
+  out = build(connection, search, source, target)
   return json.dumps(out)
 
 

--- a/tesserae/utils/exports/json.py
+++ b/tesserae/utils/exports/json.py
@@ -34,12 +34,12 @@ def build(connection, search_id):
     obj : dict
       JSON-compatible dictionary with search metadata and results.
   """
-  search = connection.find(Search.collection, id=search_id)
+  search = connection.find(Search.collection, id=search_id)[0]
   results = connection.find(Match.collection, search_id=search_id)
   source = connection.find(Text.collection,
-                           id=search.parameters['source']['object_id'])
+                           id=search.parameters['source']['object_id'])[0]
   target = connection.find(Text.collection,
-                           id=search.parameters['target']['object_id'])
+                           id=search.parameters['target']['object_id'])[0]
   
   results.sort(key=lambda x: x.score, reverse=True)
   max_score = max(results[0].score, 10)

--- a/tesserae/utils/exports/xml.py
+++ b/tesserae/utils/exports/xml.py
@@ -38,12 +38,12 @@ def build(connection, search_id):
       Root node of the XML tree with search metadata and results inside.
   """
   # Pull the search and text data from the database.
-  search = connection.find(Search.collection, id=search_id)
+  search = connection.find(Search.collection, id=search_id)[0]
   results = connection.find(Match.collection, search_id=search_id)
   source = connection.find(Text.collection,
-                           id=search.parameters['source']['object_id'])
+                           id=search.parameters['source']['object_id'])[0]
   target = connection.find(Text.collection,
-                           id=search.parameters['target']['object_id'])
+                           id=search.parameters['target']['object_id'])[0]
   
   # Sort the search results by score and get the max and min scores.
   results.sort(key=lambda x: x.score, reverse=True)

--- a/tesserae/utils/exports/xml.py
+++ b/tesserae/utils/exports/xml.py
@@ -1,0 +1,176 @@
+"""Tools for exporting searches as XML.
+
+Functions
+---------
+build
+  Construct an XML tree from a completed Tesserae search.
+dump
+  Dump a Tesserae search to file as XML.
+dumps
+  Dump a Tesserae search to an XML string.
+format_result
+  Convert a search result into an XML element.
+
+Notes
+-----
+The XML tree defined here is based on the XML output of v3.
+"""
+import math
+import xml.etree.ElementTree as ET
+
+from tesserae.db.entities import Match, Search, Text, Unit
+from tesserae.utils.exports.highlight import highlight_matches
+
+  
+def build(connection, search_id):
+  """Construct an XML tree from a completed Tesserae search.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  
+  Returns
+  -------
+    root : `xml.etree.ElementTree.Element`
+      Root node of the XML tree with search metadata and results inside.
+  """
+  # Pull the search and text data from the database.
+  search = connection.find(Search.collection, id=search_id)
+  results = connection.find(Match.collection, search_id=search_id)
+  source = connection.find(Text.collection,
+                           id=search.parameters['source']['object_id'])
+  target = connection.find(Text.collection,
+                           id=search.parameters['target']['object_id'])
+  
+  # Sort the search results by score and get the max and min scores.
+  results.sort(key=lambda x: x.score, reverse=True)
+  max_score = max(results[0].score, 10)
+  min_score = int(math.floor(results[-1].score))
+
+  # The root element contains most search parameters as attributes.
+  root = ET.Element(
+    'results',
+    attrib={
+      'source': f'{source.author.lower()}.{source.title.lower().replace(" ", "_")}',
+      'target': f'{target.author.lower()}.{target.title.lower().replace(" ", "_")}',
+      'unit': search.parameters['source']['unit'].lower(),
+      'feature': search.parameters['method']['feature'].lower(),
+      'sessionID': search.id,
+      'stop': len(search.parameters['method']['stopwrods']),
+      'stbasis': '',
+      'max_dist': f'{search.parameters["method"]["max_distance"]}',
+      'dibasis': f'{search.parameters["method"]["distance_basis"]}',
+      'cutoff': f'{min_score}',
+    }
+  )
+
+  # v3 included comments with the Tesserae version and stopwords.
+  ET.SubElement(root, 'comment', text='V5 Results.')
+  ET.SubElement(root, 'commmonwords',
+                text=', '.join(search.stopwords))
+
+  # Each result is converted to an XML element and added to the tree.
+  for r in results:
+    format_result(root, r, max_score)
+  
+  return root
+
+
+def dump(connection, search_id, filepath):
+  """Dump a Tesserae search to file as XML.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  filepath : str
+    Path to the output XML file.
+  """
+  # The xml module does not have a native file write, so first convert to
+  # string, then dump the string to file.
+  out = dumps(connection, search_id)
+  with open(filepath, 'w') as f:
+    f.write(out)
+
+
+def dumps(connection, search_id):
+  """Dump a Tesserae search to an XML string.
+
+  Parameters
+  ----------
+  connection : tesserae.db.TessMongoConnection
+    Connection to the MongoDB instance.
+  search_id : str or `bson.objectid.ObjectID`
+    The database id of the search to serialize.
+  
+  Returns
+  -------
+    out : str
+      XML string with search metadata and results.
+  """
+  out = build(connection, search_id)
+  return ET.tostring(out)
+
+
+def format_result(root, match, max_score):
+  """Convert a search result into an XML element.
+
+  Parameters
+  ----------
+  root : xml.etree.ElementTree.Element
+    The root element of the XML tree being constructed.
+  match : tesserae.db.entities.Match
+    The result to serialize.
+  max_score : float
+    The max observed score in the search. Required for normalization.
+  """
+  # This element contains the match word and score data as attributes and the
+  # source and target units as sub-elements.
+  tessdata = ET.SubElement(root, 'tessdata', attrib={
+    'keywords': ', '.join(match.matched_features),
+    'score': f'{match.score * 10 / max_score}',
+    'raw_score': f'{match.score}'
+  })
+
+  # Match words are highlighted with span tags in v3 XML.
+  markup = ('<span class="matched">', '</span>')
+
+  # Add the source unit element to the result with locus data as attributes
+  # and the text with highlights as inner text.
+  ET.SubElement(tessdata, 'phrase',
+    attrs={
+      'text': 'source',
+      'work': ' '.join(match.source_tag.split()[:-1]),
+      'unitId': str(match.source_unit)
+                if not isinstance(match.source_unit, Unit)
+                else str(match.source_unit.id),
+      'line': match.source_tag.split()[-1]
+    },
+    text=highlight_matches(
+      match.source_snippet,
+      [i[0] for i in match.highlight],
+      markup=markup
+    )
+  )
+
+  # Add the target unit element to the result with locus data as attributes
+  # and the text with highlights as inner text.
+  ET.SubElement(tessdata, 'phrase',
+    attrs={
+      'text': 'target',
+      'work': ' '.join(match.target_tag.split()[:-1]),
+      'unitId': str(match.target_unit)
+                if not isinstance(match.target_unit, Unit)
+                else str(match.target_unit.id),
+      'line': match.target_tag.split()[-1]
+    },
+    text=highlight_matches(
+      match.target_snippet,
+      [i[0] for i in match.highlight],
+      markup=markup)
+  )

--- a/tesserae/utils/exports/xml.py
+++ b/tesserae/utils/exports/xml.py
@@ -117,7 +117,7 @@ def dumps(connection, search, source, target):
     out : str
       XML string with search metadata and results.
   """
-  out = build(connection, search)
+  out = build(connection, search, source, target)
   return ET.tostring(out)
 
 

--- a/tesserae/utils/paging.py
+++ b/tesserae/utils/paging.py
@@ -1,9 +1,9 @@
 """Paging utility for easy iteration.
 
-Functions
----------
-pages
-    Iterate over pages of results.
+Classes
+-------
+Pager
+    Iterate over pages of results in the database.
 """
 import math
 
@@ -11,18 +11,65 @@ from tesserae.utils.search import get_results, get_results_count, PageOptions
 
 
 class Pager(PageOptions):
+    """Iterate over pages of results in the database.
+
+    Parameters
+    ----------
+    connection : `tesserae.db.mongodb.TessMongoConection`
+        Connection to the MongoDB instance.
+    search_id : str or `bson.objectid.ObjectID`
+        The database ID of the search to paginate.
+    sort_by : str
+        The document field on which to sort pages. Default: ``'score'``.
+    sort_order : {'descending','ascending'}
+        The order in which to sort along ``sort_by``.
+        Default: ``'descending'``.
+    per_page : int
+        The number of results to include per page. Default: ``200``.
+    
+    Attributes
+    ----------
+    connection : `tesserae.db.mongodb.TessMongoConection`
+        Connection to the MongoDB instance.
+    search_id : str or `bson.objectid.ObjectID`
+        The database ID of the search to paginate.
+    results_count : int
+        The total number of results in the given search.
+    page_count : int
+        The number of pages given ``self.results_count`` and
+        ``self.per_page``.
+    """
     def __init__(self, connection, search_id, sort_by='score', sort_order='descending', per_page=200):
         super().__init__(sort_by='score', sort_order='descending', per_page=200)
         self.connection = connection
         self.search_id = search_id
         self.results_count = get_results_count(connection, search_id)
         self.page_count = int(math.ceil(self.results_count / per_page))
+        self.current_page = None
         
         self._start_page = None
         self._end_page = None
         self._iter_step = None
 
-    def __call__(self, start, end=None, step=1):
+    def __call__(self, start=0, end=None, step=1):
+        """Iterate over all pages with current paging settings.
+        
+        Parameters
+        ----------
+        start : int
+            The first page to retrieve. Default: 0.
+        end : int, optional
+            The last page to retrieve. If not provided, defaults to
+            ``self.page_count``.
+        step : int, optional
+            The step between returned pages, acts as in `range`. If not
+            provided, defaults to ``1``.
+
+        Returns
+        -------
+        Iterator over the requested pages.
+        """
+        self.page_count = int(math.ceil(self.results_count / self.per_page))
         self._start_page = start
         self._end_page = end if end else self.page_count
         self._iter_step = step
@@ -30,6 +77,23 @@ class Pager(PageOptions):
         return self.__iter__()
 
     def __getitem__(self, start, end=None, step=1):
+        """Retrieve pages or slices by index with current paging settings.
+        
+        Parameters
+        ----------
+        start : int
+            The first page to retrieve. Default: 0.
+        end : int, optional
+            The last page to retrieve. If not provided, defaults to
+            ``self.page_count``.
+        step : int, optional
+            The step between returned pages, acts as in `range`. If not
+            provided, defaults to ``1``.
+
+        Returns
+        -------
+        Array of results over the requested pages.
+        """
         if not end:
             self.page_number = start
             out = get_results(self.connection, self.search_id, self)
@@ -41,11 +105,32 @@ class Pager(PageOptions):
         return out
 
     def __iter__(self):
-        self.page_number = self._start_page
+        """Iterate over pages of results."""
+        # Recompute this in case it has changed.
+        self.page_count = int(math.ceil(self.results_count / self.per_page))
+
+        # By default, iterate over all results in the search.
+        if self._start_page is None:
+            self._start_page = 0
+
+        if self._end_page is None:
+            self._end_page = self.page_count
+        
+        if self._iter_step is None:
+            self._iter_step = 1
+
+        self.current_page = self._start_page
         return self
     
     def __next__(self):
-        if self.page_number > self.end:
+        """Get the next page or halt iteration."""
+        if self.current_page > self._end_page:
+            # Reset the defaults
+            self._start_page = None
+            self._end_page = None
+            self._iter_step = None
             raise StopIteration
+        
         yield get_results(self.connection, self.search_id, self)
+
         self.page_number += self._iter_step

--- a/tesserae/utils/paging.py
+++ b/tesserae/utils/paging.py
@@ -1,0 +1,51 @@
+"""Paging utility for easy iteration.
+
+Functions
+---------
+pages
+    Iterate over pages of results.
+"""
+import math
+
+from tesserae.utils.search import get_results, get_results_count, PageOptions
+
+
+class Pager(PageOptions):
+    def __init__(self, connection, search_id, sort_by='score', sort_order='descending', per_page=200):
+        super().__init__(sort_by='score', sort_order='descending', per_page=200)
+        self.connection = connection
+        self.search_id = search_id
+        self.results_count = get_results_count(connection, search_id)
+        self.page_count = int(math.ceil(self.results_count / per_page))
+        
+        self._start_page = None
+        self._end_page = None
+        self._iter_step = None
+
+    def __call__(self, start, end=None, step=1):
+        self._start_page = start
+        self._end_page = end if end else self.page_count
+        self._iter_step = step
+        
+        return self.__iter__()
+
+    def __getitem__(self, start, end=None, step=1):
+        if not end:
+            self.page_number = start
+            out = get_results(self.connection, self.search_id, self)
+        else:
+            out = []
+            for page in range(start, end, step):
+                self.page_number = page
+                out.append(get_results(self.connection, self.search_id, self))
+        return out
+
+    def __iter__(self):
+        self.page_number = self._start_page
+        return self
+    
+    def __next__(self):
+        if self.page_number > self.end:
+            raise StopIteration
+        yield get_results(self.connection, self.search_id, self)
+        self.page_number += self._iter_step


### PR DESCRIPTION
Added functions to export searches to CSV (with user-determined delimiter), XML, and JSON to `tesserae.utils.export`. Also added a CLI script to call this functionality, accessible through `tesserae.cli.export`.